### PR TITLE
Ss develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 manifest.json
 test.txt
 packrat/
+rsconnect/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+manifest.json
+test.txt
+packrat/

--- a/global.R
+++ b/global.R
@@ -35,8 +35,8 @@ date_update <- max(trustData$Date)
 
 date_update <- format(date_update, "%d/%m/%Y")
 
-divisions_labels <- list("Local Partnerships- Mental Healthcare" = 0,
-                         "Forensic" = 1,
+divisions_labels <- list("Mental health services" = 0,
+                         "Forensic services" = 1,
                          "Community health services" = 2)
   
 # recode new criticality

--- a/reports/plumber.R
+++ b/reports/plumber.R
@@ -1,6 +1,6 @@
 
 library(rmarkdown)
-library(tidyverse)
+#library(tidyverse)
 library(scales)
 library(lubridate)
 library(urltools)

--- a/reports/team_quarterly_api.Rmd
+++ b/reports/team_quarterly_api.Rmd
@@ -9,7 +9,7 @@ params:
 ```{r setup, include=FALSE}
 
 library(lubridate)
-library(tidyverse)
+#library(tidyverse)
 library(scales)
 library(pins)
 
@@ -174,7 +174,8 @@ if(params$carer_su == "bothCarerSU"){
   trend_function(two_year_data, type = "carer_dashboard")
 }
 
-trend_function(two_year_data)
+# remove - needs type setting
+#trend_function(two_year_data)
 
 ```
 

--- a/ui.R
+++ b/ui.R
@@ -13,6 +13,14 @@ function(request) {
                                    Comparisons with old data may be<br>
                                    unreliable"),
                                    icon("exclamation-triangle")
+                                   ),
+                                 notificationItem(
+                                   text = HTML("Warning:<br>
+                                   Feedback from over three years ago has<br>
+                                   been removed form the dashboard. Please 
+                                   contact the Experience team should historic 
+                                   data be required"),
+                                   icon("exclamation-triangle")
                                  ))),
     
     # dashboard siderbar----
@@ -28,7 +36,9 @@ function(request) {
       # date range
       
       dateRangeInput("dateRange", label = "Date range",
-                     start = as.Date("2020-10-01"),
+                     start = as.Date(paste0(year(today()) - 3, "-",
+                                            month(today()), "-",
+                                            "01")),
                      end = Sys.Date(), startview = "year"),
       
       # Note that this goes team, directorate, division so it appears nicer

--- a/ui.R
+++ b/ui.R
@@ -8,18 +8,15 @@ function(request) {
     dashboardHeader(title = "Survey summary",
                     dropdownMenu(type = "notifications",
                                  notificationItem(
-                                   text = HTML("Warning:<br>
-                                   Criticality has been recoded<br>
-                                   Comparisons with old data may be<br>
-                                   unreliable"),
+                                   text = HTML("Warning: Feedback from over 
+                                   three<br> years ago has been removed. Please
+                                   contact<br> the Experience team if required"),
                                    icon("exclamation-triangle")
                                    ),
                                  notificationItem(
-                                   text = HTML("Warning:<br>
-                                   Feedback from over three years ago has<br>
-                                   been removed form the dashboard. Please 
-                                   contact the Experience team should historic 
-                                   data be required"),
+                                   text = HTML("Warning: Criticality has been
+                                   recoded.<br> Comparisons with old data may be<br>
+                                   unreliable"),
                                    icon("exclamation-triangle")
                                  ))),
     


### PR DESCRIPTION
Changes:
- Minor edit to match code on rconnect (just the names of the care groups)
- Edit pre-defined date filter to reflect the now 3 year rolling dataset included in the dashboard
- Add notification stating historic data over 3 years old no longer included
- Remove tidyverse as dependency in the quarterly API report Rmd (causing issues with 'textshaping' package when publishing to rconnect)